### PR TITLE
Translate CLAUDE.md documentation to Japanese

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,60 +1,60 @@
 # CLAUDE.md
 
-## Project Overview
+## プロジェクト概要
 
-SquadApp — Angular 20 + Electron 40 desktop application with type-safe IPC communication.
+SquadApp — Angular 20 + Electron 40 による型安全な IPC 通信を備えたデスクトップアプリケーション。
 
-## Tech Stack
+## 技術スタック
 
-- **Frontend**: Angular 20 (standalone components, zoneless change detection, signals)
-- **Desktop**: Electron 40 with contextBridge IPC
-- **Language**: TypeScript 5.8 (strict mode)
-- **Package Manager**: pnpm
+- **フロントエンド**: Angular 20（スタンドアロンコンポーネント、ゾーンレス変更検知、シグナル）
+- **デスクトップ**: Electron 40（contextBridge IPC）
+- **言語**: TypeScript 5.8（strict モード）
+- **パッケージマネージャー**: pnpm
 
-## Project Structure
+## プロジェクト構成
 
 ```
-src/           # Angular application source
-electron/      # Electron main process, preload script, and type definitions
-public/        # Static assets
+src/           # Angular アプリケーションソース
+electron/      # Electron メインプロセス、プリロードスクリプト、型定義
+public/        # 静的アセット
 ```
 
-## Commands
+## コマンド
 
 ```bash
-pnpm install              # Install dependencies
-ng serve                  # Start Angular dev server (localhost:4200)
-ng test                   # Run Karma/Jasmine unit tests
-pnpm build                # Production build (Angular)
-pnpm electron:build       # Compile Electron TypeScript
-pnpm electron:serve       # Build and launch Electron app
-pnpm package              # Full production package (Angular + Electron + electron-builder)
+pnpm install              # 依存関係のインストール
+ng serve                  # Angular 開発サーバー起動（localhost:4200）
+ng test                   # Karma/Jasmine ユニットテスト実行
+pnpm build                # プロダクションビルド（Angular）
+pnpm electron:build       # Electron TypeScript のコンパイル
+pnpm electron:serve       # ビルドして Electron アプリを起動
+pnpm package              # フルプロダクションパッケージ（Angular + Electron + electron-builder）
 ```
 
-## Code Style
+## コードスタイル
 
-- 2-space indentation
-- Single quotes in TypeScript
-- UTF-8 encoding, LF line endings
-- Prettier configured for Angular HTML templates (see `package.json`)
-- EditorConfig enforced (`.editorconfig`)
-- No ESLint configured
+- インデントはスペース 2 つ
+- TypeScript ではシングルクォートを使用
+- UTF-8 エンコーディング、LF 改行
+- Angular HTML テンプレート用に Prettier を設定済み（`package.json` 参照）
+- EditorConfig を適用（`.editorconfig`）
+- ESLint は未設定
 
-## TypeScript Configuration
+## TypeScript 設定
 
-Strict mode is fully enabled:
+strict モードを完全に有効化:
 - `strict`, `noImplicitReturns`, `noImplicitOverride`, `noFallthroughCasesInSwitch`
-- Angular strict templates: `strictTemplates`, `strictInjectionParameters`, `strictInputAccessModifiers`, `typeCheckHostBindings`
+- Angular strict テンプレート: `strictTemplates`, `strictInjectionParameters`, `strictInputAccessModifiers`, `typeCheckHostBindings`
 
-## Testing
+## テスト
 
-- **Framework**: Karma + Jasmine
-- **Run**: `ng test`
-- **Test files**: co-located as `*.spec.ts` alongside source files
+- **フレームワーク**: Karma + Jasmine
+- **実行**: `ng test`
+- **テストファイル**: ソースファイルと同じディレクトリに `*.spec.ts` として配置
 
-## Electron Architecture
+## Electron アーキテクチャ
 
-- Main process: `electron/main.ts` — window creation, IPC handlers
-- Preload: `electron/preload.ts` — secure `window.electronAPI` bridge via `contextBridge`
-- Types: `electron/electron.d.ts` — shared IPC type definitions
-- Security: `nodeIntegration: false`, `contextIsolation: true`
+- メインプロセス: `electron/main.ts` — ウィンドウ作成、IPC ハンドラー
+- プリロード: `electron/preload.ts` — `contextBridge` 経由で安全な `window.electronAPI` ブリッジを提供
+- 型定義: `electron/electron.d.ts` — 共有 IPC 型定義
+- セキュリティ: `nodeIntegration: false`, `contextIsolation: true`


### PR DESCRIPTION
## Summary
Translated the entire CLAUDE.md documentation file from English to Japanese to improve accessibility for Japanese-speaking developers and contributors.

## Changes Made
- Translated all section headers (Project Overview, Tech Stack, Project Structure, etc.)
- Translated all descriptive text and explanations
- Translated command descriptions and comments
- Translated technical configuration details and architecture descriptions
- Maintained all code snippets, file paths, and technical terms in their original form
- Preserved all formatting, structure, and markdown syntax

## Notes
- All technical references (Angular, Electron, TypeScript, etc.) remain in English as per standard convention
- File paths and command names remain unchanged
- Code examples and configuration values are preserved exactly as-is
- The document structure and organization remain identical to the original

https://claude.ai/code/session_01S7oVKEy75XxDpaRaroY8L1