### PR TITLE
Add test script and specify pnpm package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"src/**/*.{ts,html,css}\" \"electron/**/*.ts\" \"*.{json,md,js,mjs}\"",
+    "test": "ng test",
     "format:check": "prettier --check \"src/**/*.{ts,html,css}\" \"electron/**/*.ts\" \"*.{json,md,js,mjs}\"",
     "prepare": "husky"
   },
@@ -34,6 +35,7 @@
       "prettier --write"
     ]
   },
+  "packageManager": "pnpm@10.28.2",
   "private": true,
   "dependencies": {
     "@angular/common": "^21.1.3",


### PR DESCRIPTION
## Summary
This PR adds testing capabilities to the project and explicitly specifies the package manager version to ensure consistency across development environments.

## Key Changes
- Added `"test": "ng test"` npm script to enable running Angular tests via the standard `npm test` or `pnpm test` command
- Specified `pnpm@10.28.2` as the required package manager in `packageManager` field to enforce consistent dependency management across the team

## Implementation Details
- The test script integrates with Angular's built-in testing infrastructure (Karma/Jasmine)
- The `packageManager` field ensures all contributors use the same pnpm version, preventing potential compatibility issues and inconsistent lock files

https://claude.ai/code/session_01HyGyd8xz9PjBPT7N36jidy