### PR TITLE
docs: Add Kiro steering documentation for product, structure, and tech stack

### DIFF
--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -1,0 +1,22 @@
+# SquadApp — プロダクト概要
+
+SquadApp は、複数の Git リポジトリを横断して開発環境（Workspace）を管理するデスクトップアプリケーション。
+
+## 主な機能
+
+- Git リポジトリの登録・削除（Bare Repository として `~/.squad/` 配下にクローン）
+- リモートブランチの一覧取得・fetch
+- 複数リポジトリ × ブランチの組み合わせで Workspace を作成（git worktree ベース）
+- `.code-workspace` ファイルを自動生成し、VS Code で開く
+- Workspace の削除（worktree + ファイル + ストアのクリーンアップ）
+
+## データ管理
+
+- リポジトリ情報: `~/.squad/config/repos.json`
+- Workspace 情報: `~/.squad/config/workspaces.json`
+- Bare Repository: `~/.squad/repos/`
+- Worktree: `~/.squad/workspaces/`
+
+## 対象ユーザー
+
+複数リポジトリにまたがる機能開発を頻繁に行う開発チーム。

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -1,0 +1,44 @@
+# プロジェクト構成
+
+```
+src/                          # Angular アプリケーション
+  app/                        # ルートコンポーネント・ルーティング
+    app.ts                    # ルートコンポーネント（スタンドアロン）
+    app.config.ts             # アプリ設定（ゾーンレス、ルーター）
+    app.routes.ts             # ルート定義
+    app.html / app.css        # テンプレート・スタイル
+  lib/                        # 共有 UI コンポーネント（spartan-ng/helm ラッパー）
+    button/src/               # ボタンコンポーネント
+    utils/src/                # ユーティリティ（hlm 関数など）
+  main.ts                     # Angular ブートストラップ
+  styles.css                  # グローバルスタイル（Tailwind + テーマ変数）
+
+electron/                     # Electron メインプロセス
+  main.ts                     # アプリ起動・ウィンドウ作成・サービス初期化
+  preload.ts                  # contextBridge で window.electronAPI を公開
+  git/                        # Git 操作サービス
+    git-service.ts            # clone, worktree, fetch, branch 操作
+    code-workspace-service.ts # .code-workspace ファイル生成
+    git-validation.ts         # URL・ブランチ名バリデーション
+    git-errors.ts             # Git 固有エラークラス
+  ipc/                        # IPC 通信レイヤー
+    ipc-channels.ts           # チャネル名定数・リクエスト型・エラーコード
+    ipc-handlers.ts           # ipcMain.handle 登録
+    ipc-error-mapper.ts       # エラー → IpcResult 変換
+  store/                      # データ永続化
+    squad-store.ts            # JSON ファイルベースの CRUD ストア
+    squad-paths.ts            # ~/.squad/ 配下のパス解決
+  types/                      # 共有型定義
+    models.ts                 # エンティティ（Repository, Workspace）+ zod スキーマ
+    ipc-result.ts             # IpcResult<T> 型（Discriminated Union）
+    electron.d.ts             # window.electronAPI の型定義（Angular 側から参照）
+```
+
+## アーキテクチャパターン
+
+- Angular → `window.electronAPI.*()` → IPC → Electron メインプロセス
+- IPC レスポンスは全て `IpcResult<T>` で統一（success/error の Discriminated Union）
+- エラーは `IpcErrorCode` で分類（VALIDATION_ERROR, NOT_FOUND, GIT_OPERATION_FAILED 等）
+- データモデルは zod スキーマで定義し、型とバリデーションを一元管理
+- テストファイルはソースと同ディレクトリに `*.spec.ts` として配置
+- UI コンポーネントは `src/lib/` に spartan-ng/helm ラッパーとして配置（`@spartan-ng/helm/*` パスエイリアス）

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -1,0 +1,50 @@
+# 技術スタック
+
+## フロントエンド
+
+- Angular 21（スタンドアロンコンポーネント、ゾーンレス変更検知、シグナル）
+- TypeScript 5.9（strict モード全有効）
+- Tailwind CSS 4（PostCSS 経由、oklch カラーテーマ）
+- spartan-ng/brain + spartan-ng/helm（UI コンポーネントライブラリ）
+- class-variance-authority + clsx + tailwind-merge（スタイルユーティリティ）
+- zod 4（バリデーション・スキーマ定義）
+- RxJS 7.8
+
+## デスクトップ
+
+- Electron 40（contextBridge IPC、nodeIntegration: false、contextIsolation: true）
+- electron-builder（パッケージング）
+
+## パッケージマネージャー
+
+- pnpm 9（`packageManager` フィールドで固定）
+
+## テスト
+
+- Vitest 4（happy-dom 環境）
+- Angular テスト: `@angular/build:unit-test` ビルダー経由
+- テストファイルはソースと同ディレクトリに `*.spec.ts` として配置
+
+## リンター・フォーマッター
+
+- ESLint 9（typescript-eslint strict + stylistic、angular-eslint）
+- Prettier 3（prettier-plugin-tailwindcss 統合）
+- eslint-config-prettier で競合ルール無効化
+- husky + lint-staged でコミット時に自動実行
+
+## よく使うコマンド
+
+```bash
+pnpm install              # 依存関係インストール
+pnpm test                 # 全テスト実行（Angular + Electron）
+pnpm test:ng              # Angular テストのみ（ng test --no-watch）
+pnpm test:electron        # Electron テストのみ（vitest run electron/）
+pnpm build                # Angular プロダクションビルド
+pnpm electron:build       # Electron TypeScript コンパイル
+pnpm electron:serve       # Electron アプリ起動（ビルド込み）
+pnpm package              # フルパッケージ（Angular + Electron + electron-builder）
+pnpm lint                 # ESLint 実行
+pnpm lint:fix             # ESLint 自動修正
+pnpm format               # Prettier フォーマット
+pnpm format:check         # Prettier チェック（CI 用）
+```


### PR DESCRIPTION
## 概要

Kiro のステアリングドキュメントを `.kiro/steering/` 配下に追加し、AI アシスタントがプロジェクトのコンテキストを正確に把握できるようにする。

## 変更理由

AI アシスタント（Kiro）がコード生成やレビュー時にプロジェクト固有の技術スタック・構成・プロダクト仕様を参照できるようにするため。ステアリングドキュメントがないと、毎回コンテキストを手動で伝える必要があり非効率。

## 変更内容の詳細

- `.kiro/steering/product.md`: SquadApp のプロダクト概要（機能一覧、データ管理、対象ユーザー）
- `.kiro/steering/structure.md`: プロジェクトのディレクトリ構成とアーキテクチャパターン
- `.kiro/steering/tech.md`: 技術スタック詳細（フロントエンド、デスクトップ、テスト、リンター、よく使うコマンド）

## テスト手順

1. `.kiro/steering/` 配下の3ファイルが正しく追加されていることを確認
2. 各ドキュメントの内容がプロジェクトの実態と一致していることを確認

## 関連Issue

なし

## スクリーンショット（該当する場合）

なし（ドキュメントのみの変更）
