### PR TITLE
chore: Electron アプリのパッケージング設定を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # Compiled output
 /dist
 /dist-electron
+/release
 /tmp
 /out-tsc
 /bazel-out

--- a/angular.json
+++ b/angular.json
@@ -25,6 +25,7 @@
           },
           "configurations": {
             "production": {
+              "baseHref": "./",
               "budgets": [
                 {
                   "type": "initial",

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -37,7 +37,7 @@ function createWindow(): void {
     void mainWindow.loadURL('http://localhost:4200');
     mainWindow.webContents.openDevTools();
   } else {
-    void mainWindow.loadFile(path.join(__dirname, '../dist/squad-gui/browser/index.html'));
+    void mainWindow.loadFile(path.join(__dirname, '../dist/squad-app/browser/index.html'));
   }
 
   mainWindow.on('closed', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "squad-app",
   "version": "0.0.0",
+  "description": "Multi-repo workspace manager for development teams",
+  "author": "m4i",
   "packageManager": "pnpm@9.15.4",
   "main": "dist-electron/main.js",
   "scripts": {
@@ -8,7 +10,8 @@
     "build": "ng build",
     "electron:build": "tsc -p electron/tsconfig.json && tsc -p electron/tsconfig.preload.json",
     "electron:serve": "pnpm electron:build && electron .",
-    "package": "pnpm build && pnpm electron:build && electron-builder",
+    "package": "pnpm build && pnpm electron:build && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder",
+    "package:mac": "pnpm package --mac",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"src/**/*.{ts,html,css}\" \"electron/**/*.ts\" \"*.{json,md,js,mjs}\"",
@@ -83,5 +86,25 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.54.0",
     "vitest": "^4.0.18"
+  },
+  "build": {
+    "appId": "com.squad.app",
+    "productName": "SquadApp",
+    "directories": {
+      "output": "release"
+    },
+    "files": [
+      "dist-electron/**/*",
+      "dist/squad-app/browser/**/*"
+    ],
+    "mac": {
+      "target": [
+        "dmg",
+        "zip"
+      ],
+      "identity": null,
+      "category": "public.app-category.developer-tools"
+    },
+    "publish": null
   }
 }


### PR DESCRIPTION
## 概要

Electron アプリを electron-builder でパッケージングできるようにする設定を追加。

## 変更内容

- `package.json` に electron-builder の `build` 設定を追加（appId, productName, 出力先, 対象ファイル, macOS ターゲット）
- `package.json` に `description` / `author` フィールドを追加（electron-builder が要求）
- `package` スクリプトでコード署名の自動検出を無効化（`CSC_IDENTITY_AUTO_DISCOVERY=false`）
- macOS 向け `package:mac` スクリプトを追加
- `electron/main.ts` のプロダクションビルド読み込みパスを `squad-gui` → `squad-app` に修正
- `angular.json` に `baseHref: "./"` を追加（Electron でのファイル読み込み対応）
- `.gitignore` に `release/` ディレクトリを追加

## 動作確認

- `pnpm package:mac` で `.dmg` / `.zip` が `release/` に生成されることを確認
