### PR TITLE
feat: 新規ブランチ作成ダイアログコンポーネントの実装

### DIFF
--- a/docs/aidlc/branch-autocomplete/construction/create_branch_dialog/plan.md
+++ b/docs/aidlc/branch-autocomplete/construction/create_branch_dialog/plan.md
@@ -1,0 +1,32 @@
+# Implementation Plan: create_branch_dialog
+
+## 概要
+
+新規ブランチ作成ダイアログコンポーネントを実装する。ブランチ名バリデーション関数（フロントエンド用）、型定義、ダイアログコンポーネント本体とテンプレートを作成する。
+
+## 実装タスク
+
+### 1. バリデーション関数・型定義
+
+- [x] `branch-validation.ts`: `validateBranchName` 関数を作成（Git 命名規則に基づくバリデーション）
+- [x] `branch-validation.ts`: `checkBranchDuplicate` 関数を作成（既存ブランチとの重複チェック）
+- [x] `create-branch-dialog-types.ts`: `CreateBranchResult` インターフェースを定義
+- [x] テスト: `branch-validation.spec.ts` — `validateBranchName` の全ルールをテスト
+- [x] テスト: `branch-validation.spec.ts` — `checkBranchDuplicate` のテスト
+
+### 2. ダイアログコンポーネント
+
+- [x] `create-branch-dialog.ts`: コンポーネントクラスを作成（input/output、シグナル、computed、onCreate）
+- [x] `create-branch-dialog.html`: テンプレートを作成（起点ブランチ選択、ブランチ名入力、バリデーションエラー表示）
+
+### 3. 最終確認
+
+- [x] 全テスト実行・パス確認
+- [x] lint・format 確認
+- [x] ビルド確認
+
+## 更新履歴
+
+| 日付       | 内容     |
+| ---------- | -------- |
+| 2026-02-10 | 初版作成 |

--- a/src/app/shared/create-branch-dialog/branch-validation.spec.ts
+++ b/src/app/shared/create-branch-dialog/branch-validation.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { checkBranchDuplicate, validateBranchName } from './branch-validation';
+
+describe('validateBranchName', () => {
+  it.each(['main', 'feature/new-api', 'hotfix/v1.2.3', 'release/2024.01', 'a'])(
+    '有効なブランチ名 "%s" で null を返す',
+    (name) => {
+      expect(validateBranchName(name)).toBeNull();
+    },
+  );
+
+  it('空文字列でエラーメッセージを返す', () => {
+    expect(validateBranchName('')).toBe('ブランチ名を入力してください');
+  });
+
+  it('先頭が "." でエラーメッセージを返す', () => {
+    expect(validateBranchName('.hidden')).toBe('ブランチ名の先頭に "." は使用できません');
+  });
+
+  it('先頭が "-" でエラーメッセージを返す', () => {
+    expect(validateBranchName('-invalid')).toBe('ブランチ名の先頭に "-" は使用できません');
+  });
+
+  it('末尾が "/" でエラーメッセージを返す', () => {
+    expect(validateBranchName('feature/')).toBe('ブランチ名の末尾に "/" は使用できません');
+  });
+
+  it('末尾が ".lock" でエラーメッセージを返す', () => {
+    expect(validateBranchName('branch.lock')).toBe('ブランチ名の末尾に ".lock" は使用できません');
+  });
+
+  it('".." を含む場合にエラーメッセージを返す', () => {
+    expect(validateBranchName('feature/..invalid')).toBe('ブランチ名に ".." は使用できません');
+  });
+
+  it('"//" を含む場合にエラーメッセージを返す', () => {
+    expect(validateBranchName('feature//branch')).toBe('ブランチ名に連続する "/" は使用できません');
+  });
+
+  it.each(['~', '^', ':', '?', '*', '[', '\\'])(
+    '禁止文字 "%s" を含む場合にエラーメッセージを返す',
+    (char) => {
+      expect(validateBranchName(`feature${char}branch`)).toBe(
+        'ブランチ名に使用できない文字が含まれています',
+      );
+    },
+  );
+
+  it('スペースを含む場合にエラーメッセージを返す', () => {
+    expect(validateBranchName('feature branch')).toBe(
+      'ブランチ名に使用できない文字が含まれています',
+    );
+  });
+
+  it('制御文字を含む場合にエラーメッセージを返す', () => {
+    expect(validateBranchName('feature\x01branch')).toBe(
+      'ブランチ名に使用できない文字が含まれています',
+    );
+    expect(validateBranchName('feature\x7fbranch')).toBe(
+      'ブランチ名に使用できない文字が含まれています',
+    );
+  });
+});
+
+describe('checkBranchDuplicate', () => {
+  it('既存ブランチに同名が存在する場合にエラーメッセージを返す', () => {
+    expect(checkBranchDuplicate('main', ['main', 'develop'])).toBe(
+      '同名のブランチが既に存在します',
+    );
+  });
+
+  it('既存ブランチに同名が存在しない場合に null を返す', () => {
+    expect(checkBranchDuplicate('feature/new', ['main', 'develop'])).toBeNull();
+  });
+
+  it('空の既存ブランチ一覧で null を返す', () => {
+    expect(checkBranchDuplicate('main', [])).toBeNull();
+  });
+});

--- a/src/app/shared/create-branch-dialog/branch-validation.ts
+++ b/src/app/shared/create-branch-dialog/branch-validation.ts
@@ -1,0 +1,50 @@
+/**
+ * ブランチ名を Git 命名規則に基づいて検証する。
+ * @returns エラーメッセージ。有効な場合は null
+ */
+export function validateBranchName(branch: string): string | null {
+  if (branch.length === 0) {
+    return 'ブランチ名を入力してください';
+  }
+
+  if (branch.startsWith('.')) {
+    return 'ブランチ名の先頭に "." は使用できません';
+  }
+
+  if (branch.startsWith('-')) {
+    return 'ブランチ名の先頭に "-" は使用できません';
+  }
+
+  if (branch.endsWith('/')) {
+    return 'ブランチ名の末尾に "/" は使用できません';
+  }
+
+  if (branch.endsWith('.lock')) {
+    return 'ブランチ名の末尾に ".lock" は使用できません';
+  }
+
+  if (branch.includes('..')) {
+    return 'ブランチ名に ".." は使用できません';
+  }
+
+  if (branch.includes('//')) {
+    return 'ブランチ名に連続する "/" は使用できません';
+  }
+
+  if (/[\s~^:?*[\\\x00-\x1f\x7f]/.test(branch)) {
+    return 'ブランチ名に使用できない文字が含まれています';
+  }
+
+  return null;
+}
+
+/**
+ * 既存ブランチ一覧との重複を検証する。
+ * @returns エラーメッセージ。重複がない場合は null
+ */
+export function checkBranchDuplicate(branch: string, existingBranches: string[]): string | null {
+  if (existingBranches.includes(branch)) {
+    return '同名のブランチが既に存在します';
+  }
+  return null;
+}

--- a/src/app/shared/create-branch-dialog/create-branch-dialog-types.ts
+++ b/src/app/shared/create-branch-dialog/create-branch-dialog-types.ts
@@ -1,0 +1,7 @@
+/** 新規ブランチ作成ダイアログの確定結果 */
+export interface CreateBranchResult {
+  /** 起点ブランチ名 */
+  baseBranch: string;
+  /** 新規ブランチ名 */
+  newBranchName: string;
+}

--- a/src/app/shared/create-branch-dialog/create-branch-dialog.html
+++ b/src/app/shared/create-branch-dialog/create-branch-dialog.html
@@ -1,0 +1,43 @@
+<form class="flex flex-col gap-4" (submit)="onCreate(); $event.preventDefault()">
+  <hlm-dialog-header>
+    <h3 hlmDialogTitle>新規ブランチを作成</h3>
+    <p hlmDialogDescription>起点ブランチを選択し、新しいブランチ名を入力してください。</p>
+  </hlm-dialog-header>
+
+  <!-- 起点ブランチ -->
+  <div hlmField>
+    <label hlmFieldLabel for="base-branch">起点ブランチ</label>
+    <app-branch-combobox
+      id="base-branch"
+      [branches]="branches()"
+      [value]="baseBranch()"
+      placeholder="起点ブランチを検索..."
+      (valueChange)="baseBranch.set($event)"
+    />
+  </div>
+
+  <!-- 新規ブランチ名 -->
+  <div hlmField [attr.data-invalid]="displayError() ? true : null">
+    <label hlmFieldLabel for="new-branch-name">新規ブランチ名</label>
+    <input
+      hlmInput
+      id="new-branch-name"
+      type="text"
+      placeholder="feature/new-api"
+      [value]="newBranchName()"
+      (input)="newBranchName.set($any($event.target).value)"
+      (blur)="touched.set(true)"
+      [attr.aria-invalid]="displayError() ? true : null"
+      [attr.aria-describedby]="displayError() ? 'new-branch-name-error' : null"
+      autocomplete="off"
+    />
+    @if (displayError()) {
+      <hlm-field-error id="new-branch-name-error">{{ displayError() }}</hlm-field-error>
+    }
+  </div>
+
+  <div hlmDialogFooter>
+    <button hlmBtn variant="outline" type="button" brnDialogClose>キャンセル</button>
+    <button hlmBtn type="submit" [disabled]="!canCreate()">作成</button>
+  </div>
+</form>

--- a/src/app/shared/create-branch-dialog/create-branch-dialog.ts
+++ b/src/app/shared/create-branch-dialog/create-branch-dialog.ts
@@ -1,0 +1,96 @@
+import { Component, computed, inject, input, linkedSignal, output, signal } from '@angular/core';
+import { BrnDialogClose, BrnDialogRef } from '@spartan-ng/brain/dialog';
+import { HlmButtonImports } from '@spartan-ng/helm/button';
+import { HlmDialogImports } from '@spartan-ng/helm/dialog';
+import { HlmFieldImports } from '@spartan-ng/helm/field';
+import { HlmInputImports } from '@spartan-ng/helm/input';
+import { BranchComboboxComponent } from '../branch-combobox/branch-combobox';
+import { checkBranchDuplicate, validateBranchName } from './branch-validation';
+import type { CreateBranchResult } from './create-branch-dialog-types';
+
+@Component({
+  selector: 'app-create-branch-dialog',
+  standalone: true,
+  templateUrl: './create-branch-dialog.html',
+  imports: [
+    BrnDialogClose,
+    BranchComboboxComponent,
+    HlmButtonImports,
+    HlmDialogImports,
+    HlmFieldImports,
+    HlmInputImports,
+  ],
+})
+export class CreateBranchDialogComponent {
+  private readonly dialogRef = inject(BrnDialogRef);
+
+  /** リモートブランチ一覧 */
+  readonly branches = input.required<string[]>();
+
+  /** デフォルトブランチ名（起点ブランチの初期値） */
+  readonly defaultBranch = input.required<string>();
+
+  /** 作成確定時のイベント */
+  readonly created = output<CreateBranchResult>();
+
+  /**
+   * 起点ブランチ（defaultBranch input に連動して初期化）。
+   * ユーザーが変更した後は defaultBranch の変更に追従しない。
+   */
+  protected readonly baseBranch = linkedSignal<string, string | null>({
+    source: this.defaultBranch,
+    computation: (defaultBranch, previous) => previous?.value ?? defaultBranch,
+  });
+
+  /** 新規ブランチ名 */
+  protected readonly newBranchName = signal('');
+
+  /** 入力欄がタッチされたか（blur 後にエラー表示を開始） */
+  protected readonly touched = signal(false);
+
+  /**
+   * 新規ブランチ名のバリデーションエラー。
+   * 空文字の場合は null を返す（displayError で touched 状態に応じて表示制御するため）。
+   */
+  protected readonly branchNameError = computed(() => {
+    const name = this.newBranchName();
+    if (name === '') return null;
+
+    const validationError = validateBranchName(name);
+    if (validationError) return validationError;
+
+    const duplicateError = checkBranchDuplicate(name, this.branches());
+    if (duplicateError) return duplicateError;
+
+    return null;
+  });
+
+  /** 表示用エラーメッセージ（touched 後のみ表示） */
+  protected readonly displayError = computed(() => {
+    if (!this.touched()) return null;
+    const name = this.newBranchName();
+    if (name === '') return 'ブランチ名を入力してください';
+    return this.branchNameError();
+  });
+
+  /** 作成ボタンの有効/無効 */
+  protected readonly canCreate = computed(() => {
+    const name = this.newBranchName();
+    if (name === '') return false;
+    if (this.baseBranch() === null) return false;
+    if (this.branchNameError() !== null) return false;
+    return true;
+  });
+
+  /** 作成ボタンクリック時 */
+  protected onCreate(): void {
+    if (!this.canCreate()) return;
+    const baseBranch = this.baseBranch();
+    if (baseBranch === null) return;
+    this.created.emit({
+      baseBranch,
+      newBranchName: this.newBranchName(),
+    });
+    this.dialogRef.close();
+  }
+}

--- a/src/app/workspaces/workspace-create-form.html
+++ b/src/app/workspaces/workspace-create-form.html
@@ -76,17 +76,25 @@
                             (valueChange)="selectBranch(repo.id, $event)"
                           />
                         </div>
-                        <button
-                          hlmBtn
-                          variant="outline"
-                          size="sm"
-                          type="button"
-                          [disabled]="creating()"
-                          (click)="openCreateBranchDialog(repo.id)"
-                          aria-label="新規ブランチを作成"
-                        >
-                          <ng-icon hlm name="lucideGitBranchPlus" size="sm" />
-                        </button>
+                        <hlm-dialog>
+                          <button
+                            hlmBtn
+                            variant="outline"
+                            type="button"
+                            [disabled]="creating()"
+                            hlmDialogTrigger
+                            aria-label="新規ブランチを作成"
+                          >
+                            <ng-icon hlm name="lucideGitBranchPlus" size="sm" />
+                          </button>
+                          <hlm-dialog-content *hlmDialogPortal>
+                            <app-create-branch-dialog
+                              [branches]="branchesMap().get(repo.id) ?? []"
+                              [defaultBranch]="getDefaultBranch(repo.id)"
+                              (created)="onBranchCreated(repo.id, $event)"
+                            />
+                          </hlm-dialog-content>
+                        </hlm-dialog>
                       </div>
                     } @else {
                       <div class="flex items-center gap-2 py-1">

--- a/src/app/workspaces/workspace-create-form.ts
+++ b/src/app/workspaces/workspace-create-form.ts
@@ -13,6 +13,8 @@ import { HlmInputImports } from '@spartan-ng/helm/input';
 import { HlmSeparatorImports } from '@spartan-ng/helm/separator';
 import { HlmSpinnerImports } from '@spartan-ng/helm/spinner';
 import { BranchComboboxComponent } from '../shared/branch-combobox/branch-combobox';
+import { CreateBranchDialogComponent } from '../shared/create-branch-dialog/create-branch-dialog';
+import type { CreateBranchResult } from '../shared/create-branch-dialog/create-branch-dialog-types';
 import { RepositoryService } from '../services/repository.service';
 import { WorkspaceService } from '../services/workspace.service';
 import type { Repository, Workspace } from '../../../electron/types/models';
@@ -37,6 +39,7 @@ export type BranchSelection =
   imports: [
     BrnDialogClose,
     BranchComboboxComponent,
+    CreateBranchDialogComponent,
     HlmButtonImports,
     HlmCardImports,
     HlmCheckboxImports,
@@ -159,17 +162,18 @@ export class WorkspaceCreateFormComponent {
     this.selectionError.set(null);
   }
 
-  /**
-   * 新規ブランチ作成ダイアログを開く。
-   *
-   * Unit 3 (create_branch_dialog) で実装されるダイアログを呼び出す。
-   * 現時点ではスタブとして定義し、Unit 3 統合時に実装を差し替える。
-   */
-  protected openCreateBranchDialog(repoId: string): void {
-    console.warn(`[TODO] Unit 3 で実装予定: CreateBranchDialog for repo ${repoId}`);
-    // TODO: Unit 3 で CreateBranchDialogComponent を実装後、
-    //       HlmDialogService を使ってダイアログを開き、
-    //       戻り値を setNewBranch() に渡す。
+  /** 新規ブランチ作成ダイアログの確定結果を処理する */
+  protected onBranchCreated(repoId: string, result: CreateBranchResult): void {
+    this.setNewBranch(repoId, {
+      sourceBranch: result.baseBranch,
+      newBranchName: result.newBranchName,
+    });
+  }
+
+  /** テンプレート用: リポジトリのデフォルトブランチを取得する */
+  protected getDefaultBranch(repoId: string): string {
+    const branches = this.branchesMap().get(repoId) ?? [];
+    return branches.includes('main') ? 'main' : (branches[0] ?? 'main');
   }
 
   /** テンプレート用: リポジトリの現在の選択ブランチ名を取得する */


### PR DESCRIPTION
## 概要

Workspace 作成フォームに新規ブランチ作成ダイアログコンポーネントを実装し、統合する。
ブランチ選択オートコンプリート機能（Unit 3: create_branch_dialog）として、起点ブランチの選択と新規ブランチ名の入力・バリデーション・重複チェックを提供する。

## 変更理由

Workspace 作成フロー内でブランチの新規作成を完結させるため。
これまでスタブとして定義されていた「新規作成」ボタンの処理を、実際のダイアログコンポーネントに置き換える。

## 変更内容の詳細

### 新規ファイル

- `src/app/shared/create-branch-dialog/branch-validation.ts` — Git 命名規則に基づくブランチ名バリデーション関数（`validateBranchName`, `checkBranchDuplicate`）
- `src/app/shared/create-branch-dialog/branch-validation.spec.ts` — バリデーション関数のユニットテスト（24テスト）
- `src/app/shared/create-branch-dialog/create-branch-dialog-types.ts` — `CreateBranchResult` インターフェース定義
- `src/app/shared/create-branch-dialog/create-branch-dialog.ts` — ダイアログコンポーネント本体（シグナルベース、`linkedSignal` による起点ブランチ初期化）
- `src/app/shared/create-branch-dialog/create-branch-dialog.html` — ダイアログテンプレート（起点ブランチ選択 + ブランチ名入力 + バリデーションエラー表示）
- `docs/aidlc/branch-autocomplete/construction/create_branch_dialog/plan.md` — 実装プラン

### 変更ファイル

- `src/app/workspaces/workspace-create-form.ts` — スタブメソッド `openCreateBranchDialog` を削除し、`onBranchCreated` / `getDefaultBranch` メソッドを追加。`CreateBranchDialogComponent` を imports に追加
- `src/app/workspaces/workspace-create-form.html` — 「新規作成」ボタンを `hlm-dialog` + `hlmDialogTrigger` パターンに変更し、`CreateBranchDialogComponent` をテンプレートベースで統合

## テスト手順

1. `pnpm test` で全テスト実行（Angular 33テスト + Electron 141テスト = 全174テストパス）
2. `pnpm lint` — ESLint パス
3. `pnpm format:check` — Prettier パス
4. Workspace 作成フォームで「新規作成」ボタンをクリックし、ダイアログが表示されることを確認
5. ダイアログ内で起点ブランチをオートコンプリートで選択できることを確認
6. 無効なブランチ名（例: `feature/..invalid`）入力時にバリデーションエラーが表示されることを確認
7. 既存ブランチ名入力時に重複エラーが表示されることを確認
8. 有効なブランチ名入力後、作成ボタンクリックでダイアログが閉じ、フォームに反映されることを確認

## 関連

- 設計ドキュメント: `docs/aidlc/branch-autocomplete/construction/create_branch_dialog/design.md`
- 対応ストーリー: US3, US4, US5（AC8〜AC14）
- 依存 Unit: Unit 1 (branch_combobox) — `BranchComboboxComponent` を再利用
