### PR TITLE
feat: Workspace作成時の新規ブランチ作成機能をバックエンド〜フロントエンド全レイヤーに実装

### DIFF
--- a/docs/aidlc/branch-autocomplete/construction/new_branch_worktree/plan.md
+++ b/docs/aidlc/branch-autocomplete/construction/new_branch_worktree/plan.md
@@ -8,48 +8,49 @@ Workspace 作成時に、新規ブランチを起点ブランチから作成し�
 
 ### 1. GitService — createBranch() 追加 + addWorktree() 拡張
 
-- [ ] `createBranch(repoName, newBranch, sourceBranch)` メソッドを追加
-- [ ] `addWorktree()` に `sourceBranch?` オプショナル引数を追加し、内部で `createBranch()` に委譲
-- [ ] テスト: `createBranch()` の正常系・異常系テスト（git-service.spec.ts に追加）
-- [ ] テスト: `addWorktree()` の `sourceBranch` 引数テスト（git-service.spec.ts に追加）
+- [x] `createBranch(repoName, newBranch, sourceBranch)` メソッドを追加
+- [x] `addWorktree()` に `sourceBranch?` オプショナル引数を追加し、内部で `createBranch()` に委譲
+- [x] テスト: `createBranch()` の正常系・異常系テスト（git-service.spec.ts に追加）
+- [x] テスト: `addWorktree()` の `sourceBranch` 引数テスト（git-service.spec.ts に追加）
 
 ### 2. IPC 型拡張（ipc-channels.ts）
 
-- [ ] `WorkspaceCreateRequest.entries` に `sourceBranch?: string` を追加
+- [x] `WorkspaceCreateRequest.entries` に `sourceBranch?: string` を追加
 
 ### 3. IPC ハンドラー変更（ipc-handlers.ts）
 
-- [ ] `ResolvedWorkspaceEntry` に `sourceBranch?: string` を追加
-- [ ] `workspace:create` ハンドラーで `sourceBranch` を解決・伝搬
-- [ ] テスト: `sourceBranch` 未指定時の既存動作確認（ipc-handlers.spec.ts に追加）
-- [ ] テスト: `sourceBranch` 指定時の `addWorktree` 呼び出し確認
-- [ ] テスト: 混在エントリ（既存 + 新規ブランチ）の処理確認
-- [ ] テスト: 新規ブランチ作成失敗時のロールバック確認
+- [x] `ResolvedWorkspaceEntry` に `sourceBranch?: string` を追加
+- [x] `workspace:create` ハンドラーで `sourceBranch` を解決・伝搬
+- [x] テスト: `sourceBranch` 未指定時の既存動作確認（ipc-handlers.spec.ts に追加）
+- [x] テスト: `sourceBranch` 指定時の `addWorktree` 呼び出し確認
+- [x] テスト: 混在エントリ（既存 + 新規ブランチ）の処理確認
+- [x] テスト: 新規ブランチ作成失敗時のロールバック確認
 
 ### 4. ElectronAPI 型定義変更（electron.d.ts）
 
-- [ ] `createWorkspace` の entries 型に `sourceBranch?: string` を追加
+- [x] `createWorkspace` の entries 型に `sourceBranch?: string` を追加
 
 ### 5. preload.ts 変更
 
-- [ ] `createWorkspace` の引数型に `sourceBranch?: string` を追加
+- [x] `createWorkspace` の引数型に `sourceBranch?: string` を追加
 
 ### 6. WorkspaceService 変更（workspace.service.ts）
 
-- [ ] `createWorkspace` の entries 型に `sourceBranch?: string` を追加
+- [x] `createWorkspace` の entries 型に `sourceBranch?: string` を追加
 
 ### 7. workspace-create-form.ts — buildEntries() 変更
 
-- [ ] `buildEntries()` で新規ブランチ選択時に `sourceBranch` を含める
+- [x] `buildEntries()` で新規ブランチ選択時に `sourceBranch` を含める
 
 ### 8. 最終確認
 
-- [ ] 全テスト実行・パス確認
-- [ ] lint・format 確認
-- [ ] ビルド確認
+- [x] 全テスト実行・パス確認
+- [x] lint・format 確認
+- [x] ビルド確認
 
 ## 更新履歴
 
-| 日付       | 内容     |
-| ---------- | -------- |
-| 2026-02-11 | 初版作成 |
+| 日付       | 内容         |
+| ---------- | ------------ |
+| 2026-02-11 | 初版作成     |
+| 2026-02-11 | 全タスク完了 |

--- a/electron/git/git-service.spec.ts
+++ b/electron/git/git-service.spec.ts
@@ -323,3 +323,149 @@ describe('GitService - getRemoteBranches', () => {
     expect(branches).toEqual([]);
   });
 });
+
+// --- createBranch ---
+
+describe('GitService - createBranch', () => {
+  it('起点ブランチから新規ブランチを作成できる', async () => {
+    await cloneBareForTest(paths, remoteDir, 'test-repo');
+    await service.fetch('test-repo');
+
+    await service.createBranch('test-repo', 'feature/new', 'main');
+
+    // ブランチが作成されたことを確認
+    const repoDir = paths.repoDir('test-repo');
+    const { stdout } = await execFileAsync('git', ['branch', '--list', 'feature/new'], {
+      cwd: repoDir,
+    });
+    expect(stdout.trim()).toContain('feature/new');
+  });
+
+  it('正しい repoDir が cwd として使用される', async () => {
+    await cloneBareForTest(paths, remoteDir, 'test-repo');
+    await service.fetch('test-repo');
+
+    await service.createBranch('test-repo', 'test-branch', 'main');
+
+    const repoDir = paths.repoDir('test-repo');
+    const { stdout } = await execFileAsync('git', ['branch', '--list', 'test-branch'], {
+      cwd: repoDir,
+    });
+    expect(stdout.trim()).toContain('test-branch');
+  });
+
+  it('newBranch が空文字の場合に GitValidationError がスローされる', async () => {
+    await cloneBareForTest(paths, remoteDir, 'test-repo');
+
+    await expect(service.createBranch('test-repo', '', 'main')).rejects.toThrow(GitValidationError);
+  });
+
+  it('sourceBranch が空文字の場合に GitValidationError がスローされる', async () => {
+    await cloneBareForTest(paths, remoteDir, 'test-repo');
+
+    await expect(service.createBranch('test-repo', 'feature/new', '')).rejects.toThrow(
+      GitValidationError,
+    );
+  });
+
+  it('newBranch が Git 命名規則に違反する場合に GitValidationError がスローされる', async () => {
+    await cloneBareForTest(paths, remoteDir, 'test-repo');
+
+    await expect(service.createBranch('test-repo', '..invalid', 'main')).rejects.toThrow(
+      GitValidationError,
+    );
+  });
+
+  it('起点ブランチが存在しない場合に GitOperationError がスローされる', async () => {
+    await cloneBareForTest(paths, remoteDir, 'test-repo');
+
+    await expect(
+      service.createBranch('test-repo', 'feature/new', 'nonexistent-branch'),
+    ).rejects.toThrow(GitOperationError);
+  });
+});
+
+// --- addWorktree with sourceBranch ---
+
+describe('GitService - addWorktree (sourceBranch)', () => {
+  /**
+   * リモートに develop ブランチを追加するヘルパー
+   */
+  async function addDevelopBranch(): Promise<void> {
+    const workDir = path.join(tmpDir, 'work-for-develop');
+    await fs.mkdir(workDir, { recursive: true });
+    await execFileAsync('git', ['clone', remoteDir, '.'], { cwd: workDir });
+    await execFileAsync('git', ['config', 'user.email', 'test@test.com'], { cwd: workDir });
+    await execFileAsync('git', ['config', 'user.name', 'Test'], { cwd: workDir });
+    await execFileAsync('git', ['checkout', '-b', 'develop'], { cwd: workDir });
+    await fs.writeFile(path.join(workDir, 'develop.txt'), 'develop');
+    await execFileAsync('git', ['add', '.'], { cwd: workDir });
+    await execFileAsync('git', ['commit', '-m', 'add develop'], { cwd: workDir });
+    await execFileAsync('git', ['push', 'origin', 'develop'], { cwd: workDir });
+    await fs.rm(workDir, { recursive: true, force: true });
+  }
+
+  it('sourceBranch 省略時は branch 自身が起点として使用される', async () => {
+    await cloneBareForTest(paths, remoteDir, 'test-repo');
+    await service.fetch('test-repo');
+
+    const actualBranch = await service.addWorktree('test-repo', 'my-workspace', 'main');
+
+    expect(actualBranch).toContain('main');
+    const worktreeDir = paths.worktreeDir('my-workspace', 'test-repo');
+    const stat = await fs.stat(worktreeDir);
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  it('sourceBranch 指定時は sourceBranch から新規ブランチが作成される', async () => {
+    await addDevelopBranch();
+    await cloneBareForTest(paths, remoteDir, 'test-repo');
+    await service.fetch('test-repo');
+
+    const actualBranch = await service.addWorktree(
+      'test-repo',
+      'my-workspace',
+      'feature/from-develop',
+      'develop',
+    );
+
+    expect(actualBranch).toContain('feature/from-develop');
+    const worktreeDir = paths.worktreeDir('my-workspace', 'test-repo');
+    const stat = await fs.stat(worktreeDir);
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  it('sourceBranch 指定時に suffix 付きブランチ名が返される', async () => {
+    await cloneBareForTest(paths, remoteDir, 'test-repo');
+    await service.fetch('test-repo');
+
+    const actualBranch = await service.addWorktree(
+      'test-repo',
+      'my-workspace',
+      'feature/new',
+      'main',
+    );
+
+    // suffix が付与されている（元のブランチ名 + '-' + 8文字）
+    expect(actualBranch).toMatch(/^feature\/new-[a-f0-9]{8}$/);
+  });
+
+  it('sourceBranch 指定時に Workspace ディレクトリが自動作成される', async () => {
+    await cloneBareForTest(paths, remoteDir, 'test-repo');
+    await service.fetch('test-repo');
+
+    await service.addWorktree('test-repo', 'new-ws', 'feature/new', 'main');
+
+    const wsDir = paths.workspaceDir('new-ws');
+    const stat = await fs.stat(wsDir);
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  it('sourceBranch が Git 命名規則に違反する場合に GitValidationError がスローされる', async () => {
+    await cloneBareForTest(paths, remoteDir, 'test-repo');
+
+    await expect(
+      service.addWorktree('test-repo', 'my-workspace', 'feature/new', ''),
+    ).rejects.toThrow(GitValidationError);
+  });
+});

--- a/electron/git/git-service.ts
+++ b/electron/git/git-service.ts
@@ -53,9 +53,32 @@ export class GitService {
     await fs.rm(repoDir, { recursive: true, force: true });
   }
 
+  /**
+   * 起点ブランチから新規ブランチを作成する。
+   *
+   * @param repoName - Bare Repository 名（suffix 付き）
+   * @param newBranch - 作成するブランチ名
+   * @param sourceBranch - 起点ブランチ名（例: develop）
+   */
+  async createBranch(repoName: string, newBranch: string, sourceBranch: string): Promise<void> {
+    validateBranchName(newBranch);
+    validateBranchName(sourceBranch);
+
+    const repoDir = this.paths.repoDir(repoName);
+    await this.execGit(['branch', newBranch, sourceBranch], repoDir);
+  }
+
   /** 指定ブランチの Worktree を作成する。suffix 付きブランチ名を返す */
-  async addWorktree(repoName: string, workspaceName: string, branch: string): Promise<string> {
+  async addWorktree(
+    repoName: string,
+    workspaceName: string,
+    branch: string,
+    sourceBranch?: string,
+  ): Promise<string> {
     validateBranchName(branch);
+    if (sourceBranch !== undefined) {
+      validateBranchName(sourceBranch);
+    }
 
     const repoDir = this.paths.repoDir(repoName);
     const worktreeDir = this.paths.worktreeDir(workspaceName, repoName);
@@ -68,8 +91,8 @@ export class GitService {
       const actualBranch = appendSuffix(branch, suffix);
 
       try {
-        // suffix 付きローカルブランチを作成（元ブランチから分岐）
-        await this.execGit(['branch', actualBranch, branch], repoDir);
+        // createBranch() に委譲（sourceBranch 省略時は branch 自身が起点）
+        await this.createBranch(repoName, actualBranch, sourceBranch ?? branch);
       } catch {
         // ブランチ名が重複した場合はリトライ
         continue;

--- a/electron/ipc/ipc-channels.ts
+++ b/electron/ipc/ipc-channels.ts
@@ -165,6 +165,8 @@ export interface WorkspaceCreateRequest {
     repositoryId: string;
     /** チェックアウト対象のブランチ名 */
     branch: string;
+    /** 新規ブランチの起点ブランチ名。指定時は branch を sourceBranch から新規作成する */
+    sourceBranch?: string;
   }[];
 }
 

--- a/electron/ipc/ipc-handlers.spec.ts
+++ b/electron/ipc/ipc-handlers.spec.ts
@@ -89,6 +89,7 @@ function createMockDeps(): IpcHandlerDeps {
       removeWorktree: vi.fn(),
       fetch: vi.fn(),
       getRemoteBranches: vi.fn(),
+      createBranch: vi.fn(),
     } as unknown as IpcHandlerDeps['gitService'],
     codeWorkspaceService: {
       generate: vi.fn(),
@@ -460,6 +461,7 @@ describe('workspace:create', () => {
       'backend',
       'feature-payment-abcd1234',
       'feature/payment',
+      undefined,
     );
     expect(deps.codeWorkspaceService.generate).toHaveBeenCalledWith('feature-payment-abcd1234', [
       { repoName: 'backend' },
@@ -543,6 +545,117 @@ describe('workspace:create', () => {
     expect(result).toEqual({
       success: false,
       error: { code: IpcErrorCode.GIT_OPERATION_FAILED, message: 'err' },
+    });
+  });
+
+  it('sourceBranch 未指定のエントリは addWorktree が sourceBranch=undefined で呼ばれる', async () => {
+    const repo = makeRepo();
+    const ws = makeWorkspace();
+    vi.mocked(deps.store.getRepository).mockResolvedValue(repo);
+    vi.mocked(deps.store.addWorkspace).mockResolvedValue(ws);
+    vi.mocked(deps.gitService.addWorktree).mockResolvedValue('feature/payment-abcd1234');
+    vi.mocked(deps.codeWorkspaceService.generate).mockResolvedValue(undefined);
+
+    await invoke('workspace:create', {
+      name: 'feature-payment',
+      entries: [{ repositoryId: 'repo-1', branch: 'feature/payment' }],
+    });
+
+    expect(deps.gitService.addWorktree).toHaveBeenCalledWith(
+      'backend',
+      ws.name,
+      'feature/payment',
+      undefined,
+    );
+  });
+
+  it('sourceBranch 指定のエントリは addWorktree が sourceBranch 付きで呼ばれる', async () => {
+    const repo = makeRepo();
+    const ws = makeWorkspace();
+    vi.mocked(deps.store.getRepository).mockResolvedValue(repo);
+    vi.mocked(deps.store.addWorkspace).mockResolvedValue(ws);
+    vi.mocked(deps.gitService.addWorktree).mockResolvedValue('feature/new-abcd1234');
+    vi.mocked(deps.codeWorkspaceService.generate).mockResolvedValue(undefined);
+
+    await invoke('workspace:create', {
+      name: 'feature-payment',
+      entries: [{ repositoryId: 'repo-1', branch: 'feature/new', sourceBranch: 'develop' }],
+    });
+
+    expect(deps.gitService.addWorktree).toHaveBeenCalledWith(
+      'backend',
+      ws.name,
+      'feature/new',
+      'develop',
+    );
+  });
+
+  it('混在エントリ（既存ブランチ + 新規ブランチ）が正しく処理される', async () => {
+    const repo1 = makeRepo({ id: 'repo-1', name: 'backend' });
+    const repo2 = makeRepo({ id: 'repo-2', name: 'frontend' });
+    const ws = makeWorkspace({
+      entries: [
+        { repositoryId: 'repo-1', branch: 'main' },
+        { repositoryId: 'repo-2', branch: 'feature/new' },
+      ],
+    });
+
+    vi.mocked(deps.store.getRepository).mockResolvedValueOnce(repo1).mockResolvedValueOnce(repo2);
+    vi.mocked(deps.store.addWorkspace).mockResolvedValue(ws);
+    vi.mocked(deps.gitService.addWorktree)
+      .mockResolvedValueOnce('main-11111111')
+      .mockResolvedValueOnce('feature/new-22222222');
+    vi.mocked(deps.codeWorkspaceService.generate).mockResolvedValue(undefined);
+
+    const result = await invoke('workspace:create', {
+      name: 'feature-payment',
+      entries: [
+        { repositoryId: 'repo-1', branch: 'main' },
+        { repositoryId: 'repo-2', branch: 'feature/new', sourceBranch: 'develop' },
+      ],
+    });
+
+    expect(deps.gitService.addWorktree).toHaveBeenNthCalledWith(
+      1,
+      'backend',
+      ws.name,
+      'main',
+      undefined,
+    );
+    expect(deps.gitService.addWorktree).toHaveBeenNthCalledWith(
+      2,
+      'frontend',
+      ws.name,
+      'feature/new',
+      'develop',
+    );
+    expect(result).toEqual({ success: true, data: ws });
+  });
+
+  it('新規ブランチ作成失敗時にロールバックが実行される', async () => {
+    const repo = makeRepo();
+    const ws = makeWorkspace();
+
+    vi.mocked(deps.store.getRepository).mockResolvedValue(repo);
+    vi.mocked(deps.store.addWorkspace).mockResolvedValue(ws);
+    vi.mocked(deps.gitService.addWorktree).mockRejectedValue(
+      new GitOperationError('branch create failed', 128, 'fatal: not a valid ref'),
+    );
+    vi.mocked(deps.codeWorkspaceService.remove).mockResolvedValue(undefined);
+    vi.mocked(deps.store.removeWorkspace).mockResolvedValue(undefined);
+
+    const result = await invoke('workspace:create', {
+      name: 'feature-payment',
+      entries: [{ repositoryId: 'repo-1', branch: 'feature/new', sourceBranch: 'nonexistent' }],
+    });
+
+    expect(deps.store.removeWorkspace).toHaveBeenCalledWith(ws.id);
+    expect(result).toEqual({
+      success: false,
+      error: {
+        code: IpcErrorCode.GIT_OPERATION_FAILED,
+        message: 'fatal: not a valid ref',
+      },
     });
   });
 });

--- a/electron/ipc/ipc-handlers.ts
+++ b/electron/ipc/ipc-handlers.ts
@@ -18,6 +18,8 @@ interface ResolvedWorkspaceEntry {
   repo: Repository;
   /** チェックアウト対象のブランチ名 */
   branch: string;
+  /** 新規ブランチの起点ブランチ名 */
+  sourceBranch?: string;
 }
 
 /** ロールバック時に削除対象となる作成済み Worktree の識別情報 */
@@ -221,7 +223,13 @@ export function registerIpcHandlers(deps: IpcHandlerDeps): void {
     IpcChannels.WORKSPACE_CREATE,
     async (
       _event,
-      { name, entries }: { name: string; entries: { repositoryId: string; branch: string }[] },
+      {
+        name,
+        entries,
+      }: {
+        name: string;
+        entries: { repositoryId: string; branch: string; sourceBranch?: string }[];
+      },
     ): Promise<IpcResult<Workspace>> => {
       // TODO: セキュリティ強化 — name に ../ や特殊文字が含まれた場合のパストラバーサルを防止するため、
       //       英数字・ハイフン・アンダースコアのみ許可するバリデーションを追加する
@@ -232,7 +240,7 @@ export function registerIpcHandlers(deps: IpcHandlerDeps): void {
         if (!repo) {
           return notFoundResult('Repository', entry.repositoryId);
         }
-        resolvedEntries.push({ repo, branch: entry.branch });
+        resolvedEntries.push({ repo, branch: entry.branch, sourceBranch: entry.sourceBranch });
       }
 
       // 作成済み Worktree を追跡（ロールバック用）
@@ -245,7 +253,12 @@ export function registerIpcHandlers(deps: IpcHandlerDeps): void {
 
         // 3. 各エントリに対して Worktree を作成
         for (const resolved of resolvedEntries) {
-          await gitService.addWorktree(resolved.repo.name, workspace.name, resolved.branch);
+          await gitService.addWorktree(
+            resolved.repo.name,
+            workspace.name,
+            resolved.branch,
+            resolved.sourceBranch,
+          );
           createdWorktrees.push({
             repoName: resolved.repo.name,
             workspaceName: workspace.name,

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -246,8 +246,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
    * }
    * ```
    */
-  createWorkspace: (name: string, entries: { repositoryId: string; branch: string }[]) =>
-    ipcRenderer.invoke('workspace:create', { name, entries }),
+  createWorkspace: (
+    name: string,
+    entries: { repositoryId: string; branch: string; sourceBranch?: string }[],
+  ) => ipcRenderer.invoke('workspace:create', { name, entries }),
 
   /**
    * 指定された ID の Workspace を削除する。

--- a/electron/types/electron.d.ts
+++ b/electron/types/electron.d.ts
@@ -156,7 +156,7 @@ export interface ElectronAPI {
    */
   createWorkspace: (
     name: string,
-    entries: { repositoryId: string; branch: string }[],
+    entries: { repositoryId: string; branch: string; sourceBranch?: string }[],
   ) => Promise<IpcResult<Workspace>>;
 
   /**

--- a/src/app/services/workspace.service.ts
+++ b/src/app/services/workspace.service.ts
@@ -10,7 +10,7 @@ export class WorkspaceService {
 
   createWorkspace(
     name: string,
-    entries: { repositoryId: string; branch: string }[],
+    entries: { repositoryId: string; branch: string; sourceBranch?: string }[],
   ): Promise<IpcResult<Workspace>> {
     return window.electronAPI.createWorkspace(name, entries);
   }

--- a/src/app/workspaces/workspace-create-form.ts
+++ b/src/app/workspaces/workspace-create-form.ts
@@ -212,22 +212,20 @@ export class WorkspaceCreateFormComponent {
     return valid;
   }
 
-  /**
-   * branchSelections から createWorkspace 用の entries を構築する。
-   *
-   * 現時点では既存の IPC インターフェース（{ repositoryId, branch }）に合わせて変換する。
-   * Unit 4 で IPC 型が拡張された後、新規ブランチの場合は sourceBranch 情報も
-   * entries に含めるように変更する。
-   */
-  private buildEntries(): { repositoryId: string; branch: string }[] {
+  private buildEntries(): { repositoryId: string; branch: string; sourceBranch?: string }[] {
     return [...this.selectedRepoIds()].map((repoId) => {
       const selection = this.branchSelections().get(repoId);
       if (!selection) {
         throw new Error(`Branch selection not found for repository: ${repoId}`);
       }
-      const branch =
-        selection.type === 'existing' ? selection.branch : selection.newBranchInfo.newBranchName;
-      return { repositoryId: repoId, branch };
+      if (selection.type === 'existing') {
+        return { repositoryId: repoId, branch: selection.branch };
+      }
+      return {
+        repositoryId: repoId,
+        branch: selection.newBranchInfo.newBranchName,
+        sourceBranch: selection.newBranchInfo.sourceBranch,
+      };
     });
   }
 


### PR DESCRIPTION
## 概要

Workspace 作成時に、新規ブランチを起点ブランチから作成して worktree を追加する機能を、バックエンドからフロントエンドまでの全レイヤーに実装する。

これは「ブランチ選択オートコンプリート」機能の Unit 4（new_branch_worktree）に対応し、Unit 1〜3 で実装済みのフロントエンド側の新規ブランチ作成フローをバックエンドで完結させる。

## 変更理由

従来の Workspace 作成では既存ブランチのみ選択可能だったが、Unit 1〜3 で新規ブランチ作成ダイアログが実装された。本 PR では、ダイアログで入力された起点ブランチ情報をバックエンドに伝搬し、`git branch <new> <source>` で新規ブランチを作成した後に worktree を追加する処理を実装する。

## 変更内容の詳細

- `GitService.createBranch()` を独立メソッドとして新規追加（ブランチ作成の単一責務）
- `GitService.addWorktree()` に `sourceBranch?` オプショナル引数を追加し、`createBranch()` に委譲
- `WorkspaceCreateRequest.entries` に `sourceBranch?: string` フィールドを追加（IPC 型拡張）
- `workspace:create` IPC ハンドラーで `sourceBranch` を解決・`addWorktree()` に伝搬
- `ElectronAPI` 型定義、`preload.ts`、`WorkspaceService` の entries 型を拡張
- `workspace-create-form.ts` の `buildEntries()` で新規ブランチ選択時に `sourceBranch` を含める
- Unit 4 実装計画ドキュメント（`plan.md`）を追加

## テスト手順

1. `pnpm test` で全テスト（Angular + Electron）を実行し、全てパスすることを確認
2. 追加したテストケース:
   - **GitService.createBranch()**: 正常系（起点ブランチからの新規ブランチ作成）、異常系（空文字、命名規則違反、存在しない起点ブランチ）— 6 テスト
   - **GitService.addWorktree() (sourceBranch)**: sourceBranch 省略時・指定時の動作、suffix 付きブランチ名、ディレクトリ自動作成、バリデーションエラー — 5 テスト
   - **IPC ハンドラー workspace:create**: sourceBranch 未指定/指定時の呼び出し確認、混在エントリ処理、新規ブランチ作成失敗時のロールバック — 4 テスト
3. `pnpm lint` / `pnpm format:check` でコード品質チェックがパスすることを確認

## 関連

- 設計ドキュメント: `docs/aidlc/branch-autocomplete/construction/new_branch_worktree/design.md`
- 実装計画: `docs/aidlc/branch-autocomplete/construction/new_branch_worktree/plan.md`
- 対応するストーリー: AC15（Workspace 作成時に新規ブランチを起点ブランチから作成できる）
