### PR TITLE
chore(build): macOS Ad Hoc コード署名の有効化とビルド設定の簡素化

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squad-app",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Multi-repo workspace manager for development teams",
   "author": "m4i",
   "packageManager": "pnpm@9.15.4",
@@ -10,7 +10,7 @@
     "build": "ng build",
     "electron:build": "tsc -p electron/tsconfig.json && node electron/build-preload.mjs",
     "electron:serve": "pnpm electron:build && electron .",
-    "package": "pnpm build && pnpm electron:build && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder",
+    "package": "pnpm build && pnpm electron:build && electron-builder",
     "package:mac": "pnpm package --mac",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -104,7 +104,7 @@
         "zip"
       ],
       "icon": "build/icon.png",
-      "identity": null,
+      "identity": "-",
       "category": "public.app-category.developer-tools"
     },
     "publish": null


### PR DESCRIPTION
## 概要

macOS 向けビルド時のコード署名設定を簡素化し、Ad Hoc 署名で安定してビルドできるようにする。
あわせてバージョンを v0.0.4 にバンプ。

## 変更内容

- `version` を `0.0.3` → `0.0.4` にバンプ
- `package` スクリプトから `CSC_IDENTITY_AUTO_DISCOVERY=false` 環境変数を削除し、electron-builder のデフォルト動作に委ねるよう簡素化
- macOS ビルド設定の `identity` を `null` → `"-"` に変更し、Ad Hoc 署名（`-` identity）を明示的に指定

## テスト

- 全テスト通過（Angular 33件 + Electron 156件）
- lint / format:check も問題なし
