### PR TITLE
fix(git): Bare Repository で最新のリモートブランチを起点に使用するよう修正

### DIFF
--- a/electron/git/git-service.spec.ts
+++ b/electron/git/git-service.spec.ts
@@ -162,6 +162,7 @@ describe('GitService - removeBareRepository', () => {
 describe('GitService - addWorktree', () => {
   it('指定ブランチの Worktree を作成できる', async () => {
     await cloneBareForTest(paths, remoteDir, 'test-repo');
+    await service.fetch('test-repo');
     await service.addWorktree('test-repo', 'my-workspace', 'main');
     const worktreeDir = paths.worktreeDir('my-workspace', 'test-repo');
     const stat = await fs.stat(worktreeDir);
@@ -170,6 +171,7 @@ describe('GitService - addWorktree', () => {
 
   it('Worktree ディレクトリ内にファイルが展開される', async () => {
     await cloneBareForTest(paths, remoteDir, 'test-repo');
+    await service.fetch('test-repo');
     await service.addWorktree('test-repo', 'my-workspace', 'main');
     const worktreeDir = paths.worktreeDir('my-workspace', 'test-repo');
     const readme = path.join(worktreeDir, 'README.md');
@@ -179,6 +181,7 @@ describe('GitService - addWorktree', () => {
 
   it('Workspace ディレクトリが自動作成される', async () => {
     await cloneBareForTest(paths, remoteDir, 'test-repo');
+    await service.fetch('test-repo');
     await service.addWorktree('test-repo', 'new-workspace', 'main');
     const wsDir = paths.workspaceDir('new-workspace');
     const stat = await fs.stat(wsDir);
@@ -194,6 +197,7 @@ describe('GitService - addWorktree', () => {
 
   it('存在しないブランチの場合に GitOperationError がスローされる', async () => {
     await cloneBareForTest(paths, remoteDir, 'test-repo');
+    await service.fetch('test-repo');
     await expect(
       service.addWorktree('test-repo', 'my-workspace', 'nonexistent-branch'),
     ).rejects.toThrow(GitOperationError);
@@ -201,12 +205,15 @@ describe('GitService - addWorktree', () => {
 
   it('3回リトライ後に全て重複した場合 GitOperationError がスローされる', async () => {
     await cloneBareForTest(paths, remoteDir, 'test-repo');
+    await service.fetch('test-repo');
 
     const spy = vi.spyOn(uuidSuffix, 'generateSuffix').mockReturnValue('bbbbbbbb');
 
     // 先に同名ブランチで worktree を作成しておく
     const repoDir = paths.repoDir('test-repo');
-    await execFileAsync('git', ['branch', 'main-bbbbbbbb', 'main'], { cwd: repoDir });
+    await execFileAsync('git', ['branch', 'main-bbbbbbbb', 'refs/remotes/origin/main'], {
+      cwd: repoDir,
+    });
     await execFileAsync(
       'git',
       ['worktree', 'add', paths.worktreeDir('pre-existing', 'test-repo'), 'main-bbbbbbbb'],
@@ -226,6 +233,7 @@ describe('GitService - addWorktree', () => {
 describe('GitService - removeWorktree', () => {
   it('既存の Worktree を削除できる', async () => {
     await cloneBareForTest(paths, remoteDir, 'test-repo');
+    await service.fetch('test-repo');
     await service.addWorktree('test-repo', 'my-workspace', 'main');
     await service.removeWorktree('test-repo', 'my-workspace');
     const worktreeDir = paths.worktreeDir('my-workspace', 'test-repo');
@@ -238,6 +246,7 @@ describe('GitService - removeWorktree', () => {
 
   it('削除後に Worktree ディレクトリが存在しない', async () => {
     await cloneBareForTest(paths, remoteDir, 'test-repo');
+    await service.fetch('test-repo');
     await service.addWorktree('test-repo', 'my-workspace', 'main');
     await service.removeWorktree('test-repo', 'my-workspace');
     await expect(fs.stat(paths.worktreeDir('my-workspace', 'test-repo'))).rejects.toThrow();

--- a/electron/git/git-service.ts
+++ b/electron/git/git-service.ts
@@ -56,16 +56,20 @@ export class GitService {
   /**
    * 起点ブランチから新規ブランチを作成する。
    *
+   * リモート追跡ブランチ（refs/remotes/origin/*）を起点として使用する。
+   * Bare Repository では git fetch で refs/remotes/origin/* のみが更新され、
+   * refs/heads/* は clone 時点のまま更新されないため、常にリモート参照を使う。
+   *
    * @param repoName - Bare Repository 名（suffix 付き）
    * @param newBranch - 作成するブランチ名
-   * @param sourceBranch - 起点ブランチ名（例: develop）
+   * @param sourceBranch - 起点ブランチ名（例: develop）。origin/ プレフィックスなしで指定する。
    */
   async createBranch(repoName: string, newBranch: string, sourceBranch: string): Promise<void> {
     validateBranchName(newBranch);
     validateBranchName(sourceBranch);
 
     const repoDir = this.paths.repoDir(repoName);
-    await this.execGit(['branch', newBranch, sourceBranch], repoDir);
+    await this.execGit(['branch', newBranch, `refs/remotes/origin/${sourceBranch}`], repoDir);
   }
 
   /** 指定ブランチの Worktree を作成する。suffix 付きブランチ名を返す */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squad-app",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Multi-repo workspace manager for development teams",
   "author": "m4i",
   "packageManager": "pnpm@9.15.4",


### PR DESCRIPTION
## 概要

Bare Repository における `createBranch` が、clone 時点の古い `refs/heads/*` を起点にしていた問題を修正。常にリモート追跡ブランチ (`refs/remotes/origin/*`) を参照するように変更した。

## 背景

Bare Repository では `git fetch` 実行時に `refs/remotes/origin/*` のみが更新され、`refs/heads/*` は clone 時点のまま更新されない。そのため、`createBranch` で `refs/heads/<branch>` を起点にすると、古いコミットからブランチが作成されてしまう。

## 変更内容

- `GitService.createBranch`: 起点を `sourceBranch` → `refs/remotes/origin/${sourceBranch}` に変更
- テスト: worktree 作成前に `fetch` を実行するよう修正し、実際の利用フローに合わせた
- バージョン: `0.1.1` → `0.1.2`

## 影響範囲

- `electron/git/git-service.ts` — `createBranch` メソッド
- `electron/git/git-service.spec.ts` — worktree 関連テスト
- `package.json` — バージョンバンプ