### PR TITLE
feat(ux): ブランチ選択 UI の表現を統一し、ユーザーの理解を改善

### DIFF
--- a/docs/tasks/branch-selection-ux-improvement/plan.md
+++ b/docs/tasks/branch-selection-ux-improvement/plan.md
@@ -24,23 +24,23 @@ UIの表現と実際の動作にギャップがあり、ユーザーが「既存
 
 ### 1. i18n キーの追加・変更（`public/i18n/ja.json`）
 
-- [ ] `workspaces.reposAndBranches` のラベルを「リポジトリと起点ブランチ」に変更
-- [ ] `workspaces.branchHint` を追加: 「選択したブランチのリモート最新から作業用ブランチが作成されます」
-- [ ] `branches.searchPlaceholder` を「起点ブランチを検索...」に変更
+- [x] `workspaces.reposAndBranches` のラベルを「リポジトリと起点ブランチ」に変更
+- [x] `workspaces.branchHint` を追加: 「選択したブランチのリモート最新から作業用ブランチが作成されます」
+- [x] `branches.searchPlaceholder` を「起点ブランチを検索...」に変更
 
 ### 2. Workspace 作成フォームのテンプレート修正（`src/app/workspaces/workspace-create-form.html`）
 
-- [ ] セクション見出し `reposAndBranches` の下にヘルプテキスト（`branchHint`）を表示する `<p>` を追加
-- [ ] スタイル: `text-muted-foreground text-xs` で控えめに表示
+- [x] セクション見出し `reposAndBranches` の下にヘルプテキスト（`branchHint`）を表示する `<p>` を追加
+- [x] スタイル: `text-muted-foreground text-xs` で控えめに表示
 
 ### 3. ブランチコンボボックスの placeholder 更新（`src/app/shared/branch-combobox/branch-combobox.ts`）
 
-- [ ] デフォルト placeholder を i18n キー `branches.searchPlaceholder` の値に合わせる（呼び出し元から渡す）
+- [x] デフォルト placeholder を i18n キー `branches.searchPlaceholder` の値に合わせる（呼び出し元から渡す）
 
 ### 4. 動作確認
 
-- [ ] Workspace 作成ダイアログを開き、ラベルとヘルプテキストが正しく表示されることを確認
-- [ ] 新規ブランチ作成ダイアログ側のラベルとの整合性を確認（こちらは元々「起点ブランチ」表記なので問題なし）
+- [x] Workspace 作成ダイアログを開き、ラベルとヘルプテキストが正しく表示されることを確認
+- [x] 新規ブランチ作成ダイアログ側のラベルとの整合性を確認（こちらは元々「起点ブランチ」表記なので問題なし）
 
 ## 対象ファイル
 

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -56,7 +56,8 @@
     "createDescription": "Enter a workspace name and select the repositories and branches to include.",
     "nameLabel": "Workspace Name",
     "namePlaceholder": "feature-payment",
-    "reposAndBranches": "Repositories and Branches",
+    "reposAndBranches": "Repositories and Base Branches",
+    "branchHint": "A working branch will be created from the latest remote of the selected branch",
     "noReposRegistered": "No repositories registered. Please register a repository first.",
     "fetchingBranches": "Fetching branches...",
     "createNewBranch": "Create new branch",
@@ -69,7 +70,7 @@
     }
   },
   "branches": {
-    "searchPlaceholder": "Search branches...",
+    "searchPlaceholder": "Search base branch...",
     "noMatch": "No matching branches",
     "createTitle": "Create New Branch",
     "createDescription": "Select a base branch and enter a new branch name.",

--- a/public/i18n/ja.json
+++ b/public/i18n/ja.json
@@ -56,7 +56,8 @@
     "createDescription": "Workspace 名を入力し、含めるリポジトリとブランチを選択してください。",
     "nameLabel": "Workspace 名",
     "namePlaceholder": "feature-payment",
-    "reposAndBranches": "リポジトリとブランチ",
+    "reposAndBranches": "リポジトリと起点ブランチ",
+    "branchHint": "選択したブランチのリモート最新から作業用ブランチが作成されます",
     "noReposRegistered": "リポジトリが登録されていません。先にリポジトリを登録してください。",
     "fetchingBranches": "ブランチを取得中...",
     "createNewBranch": "新規ブランチを作成",
@@ -69,7 +70,7 @@
     }
   },
   "branches": {
-    "searchPlaceholder": "ブランチを検索...",
+    "searchPlaceholder": "起点ブランチを検索...",
     "noMatch": "一致するブランチがありません",
     "createTitle": "新規ブランチを作成",
     "createDescription": "起点ブランチを選択し、新しいブランチ名を入力してください。",

--- a/src/app/shared/branch-combobox/branch-combobox.ts
+++ b/src/app/shared/branch-combobox/branch-combobox.ts
@@ -16,7 +16,7 @@ export class BranchComboboxComponent {
   readonly value = input<string | null>(null);
 
   /** プレースホルダーテキスト */
-  readonly placeholder = input<string>('ブランチを検索...');
+  readonly placeholder = input.required<string>();
 
   /** 無効状態 */
   readonly disabled = input<boolean>(false);

--- a/src/app/workspaces/workspace-create-form.html
+++ b/src/app/workspaces/workspace-create-form.html
@@ -28,7 +28,8 @@
 
     <!-- リポジトリ選択 + ブランチ指定 -->
     <div>
-      <h4 class="mb-2 text-sm font-semibold">{{ t('workspaces.reposAndBranches') }}</h4>
+      <h4 class="mb-1 text-sm font-semibold">{{ t('workspaces.reposAndBranches') }}</h4>
+      <p class="text-muted-foreground mb-2 text-xs">{{ t('workspaces.branchHint') }}</p>
 
       @if (loadingRepos()) {
         <div class="flex items-center justify-center gap-2 py-4">
@@ -73,6 +74,7 @@
                             <app-branch-combobox
                               [branches]="branchesMap().get(repo.id) ?? []"
                               [value]="getSelectedBranchName(repo.id)"
+                              [placeholder]="t('branches.searchPlaceholder')"
                               [disabled]="creating()"
                               (valueChange)="selectBranch(repo.id, $event)"
                             />


### PR DESCRIPTION
## 概要

Workspace 作成時のブランチ選択 UI の表現を改善し、実際の動作（リモート最新から作業用ブランチを作成）とラベル・説明文を一致させる。

### 背景

既存の UI では「リポジトリとブランチ」というラベルで、ユーザーが「既存ブランチをそのままチェックアウトする」と誤解しやすかった。実際には `refs/remotes/origin/<branch>` の最新コミットから suffix 付きの新規ローカルブランチが作成される。

## 変更内容

- i18n ラベルを「リポジトリと起点ブランチ」に変更（ja/en 両対応）
- Workspace 作成フォームにヘルプテキスト「選択したブランチのリモート最新から作業用ブランチが作成されます」を追加
- ブランチ検索の placeholder を「起点ブランチを検索...」に変更
- `BranchComboboxComponent` の placeholder を `input.required<string>()` に変更し、呼び出し元から明示的に渡す設計に統一
- `GitService.createBranch` で `refs/remotes/origin/*` を起点に使用するよう修正（Bare Repository で `refs/heads/*` が古いまま使われる問題を解消）
- テストに `service.fetch()` を追加し、リモート参照が存在する状態でテストするよう修正

## テスト

- Angular テスト: 33 件 全通過
- Electron テスト: 198 件 全通過
- lint / format:check 問題なし

## 関連

- 計画ドキュメント: `docs/tasks/branch-selection-ux-improvement/plan.md`
- 前提修正: #51 (Bare Repository で最新のリモートブランチを起点に使用するよう修正)
