### PR TITLE
style: タイポグラフィを JetBrains Mono に変更

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,12 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <app-root></app-root>

--- a/src/styles.css
+++ b/src/styles.css
@@ -7,7 +7,7 @@
 
 :root {
   color-scheme: light;
-  --font-sans: 'Geist Sans', sans-serif;
+  --font-sans: 'JetBrains Mono', sans-serif;
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.13 0.028 261.692);


### PR DESCRIPTION
## 概要

アプリケーション全体のフォントを Geist Sans から JetBrains Mono に変更。

## 変更内容

- `src/index.html`: Google Fonts から JetBrains Mono を読み込み（preconnect + stylesheet）
- `src/styles.css`: `--font-sans` CSS 変数を `'JetBrains Mono', sans-serif` に変更
