### PR TITLE
feat: Worktree 作成時にブランチの upstream を自動設定する

### DIFF
--- a/docs/aidlc/workspace-core/construction/git_operations/plan-upstream.md
+++ b/docs/aidlc/workspace-core/construction/git_operations/plan-upstream.md
@@ -1,0 +1,31 @@
+# Implementation Plan: addWorktree upstream 自動設定 (Issue #64)
+
+## 概要
+
+`addWorktree()` で Worktree を作成した後、作成されたブランチの upstream が起点ブランチを引き継いでしまう問題を修正する。Worktree 作成後に `git config` で `branch.<actualBranch>.remote` と `branch.<actualBranch>.merge` を明示的に設定し、`git push` が正しいリモートブランチに向くようにする。
+
+## 実装タスク
+
+### 1. テスト追加（TDD: Test First）
+
+- [x] `git-service.spec.ts` の `addWorktree (sourceBranch)` describe ブロック内に、Worktree 作成後にブランチの upstream remote が `origin` に設定されていることを検証するテストを追加
+- [x] 同 describe ブロック内に、Worktree 作成後にブランチの upstream merge が `refs/heads/<actualBranch>` に設定されていることを検証するテストを追加
+- [x] テスト実行・失敗確認（Red）
+
+### 2. 実装
+
+- [x] `git-service.ts` の `addWorktree()` メソッド内、`git worktree add` の後・`return actualBranch` の前に `git config branch.<actualBranch>.remote origin` を追加
+- [x] 同箇所に `git config branch.<actualBranch>.merge refs/heads/<actualBranch>` を追加
+- [x] テスト実行・パス確認（Green）
+
+### 3. 最終確認
+
+- [x] 全テスト実行・パス確認（`pnpm test:electron`）
+- [x] lint 確認（`pnpm lint`）
+- [x] ビルド確認（`pnpm electron:build`）
+
+## 更新履歴
+
+| 日付       | 内容     |
+| ---------- | -------- |
+| 2025-07-15 | 初版作成 |

--- a/electron/git/git-service.spec.ts
+++ b/electron/git/git-service.spec.ts
@@ -638,4 +638,40 @@ describe('GitService - addWorktree (sourceBranch)', () => {
       service.addWorktree('test-repo', 'my-workspace', 'feature/new', ''),
     ).rejects.toThrow(GitValidationError);
   });
+
+  it('sourceBranch 省略時も upstream が自身に設定される', async () => {
+    await cloneBareForTest(paths, remoteDir, 'test-repo');
+    await service.fetch('test-repo');
+
+    const actualBranch = await service.addWorktree('test-repo', 'my-workspace', 'main');
+
+    const repoDir = paths.repoDir('test-repo');
+    const { stdout } = await execFileAsync(
+      'git',
+      ['for-each-ref', '--format=%(upstream:short)', `refs/heads/${actualBranch}`],
+      { cwd: repoDir },
+    );
+    expect(stdout.trim()).toBe(`origin/${actualBranch}`);
+  });
+
+  it('sourceBranch 指定時も upstream が起点ブランチではなく自身に設定される', async () => {
+    await cloneBareForTest(paths, remoteDir, 'test-repo');
+    await service.fetch('test-repo');
+
+    const actualBranch = await service.addWorktree(
+      'test-repo',
+      'my-workspace',
+      'feature/upstream-test',
+      'main',
+    );
+
+    const repoDir = paths.repoDir('test-repo');
+    const { stdout } = await execFileAsync(
+      'git',
+      ['for-each-ref', '--format=%(upstream:short)', `refs/heads/${actualBranch}`],
+      { cwd: repoDir },
+    );
+    // origin/main ではなく origin/<actualBranch> であること
+    expect(stdout.trim()).toBe(`origin/${actualBranch}`);
+  });
 });

--- a/electron/git/git-service.ts
+++ b/electron/git/git-service.ts
@@ -104,6 +104,16 @@ export class GitService {
 
       // 作成したブランチで worktree を追加
       await this.execGit(['worktree', 'add', worktreeDir, actualBranch], repoDir);
+
+      // 作成したブランチの upstream を自身に設定する。
+      // sourceBranch から分岐した場合、upstream が origin/<sourceBranch> を引き継いでしまうため、
+      // 明示的に origin/<actualBranch> を設定して git push が正しいリモートブランチに向くようにする。
+      await this.execGit(['config', `branch.${actualBranch}.remote`, 'origin'], repoDir);
+      await this.execGit(
+        ['config', `branch.${actualBranch}.merge`, `refs/heads/${actualBranch}`],
+        repoDir,
+      );
+
       return actualBranch;
     }
 


### PR DESCRIPTION
## 概要

Worktree 作成時に、作成されたブランチの upstream が起点ブランチを引き継いでしまい、`git push` が意図しないリモートブランチに向いてしまう問題を修正しました。

`addWorktree()` メソッド内で Worktree 作成後に `git config` を使用して、作成されたブランチの upstream を自身（`origin/<actualBranch>`）に明示的に設定するようにしました。

## 変更内容

- `electron/git/git-service.ts` の `addWorktree()` メソッドに upstream 自動設定処理を追加
  - `git config branch.<actualBranch>.remote origin` で remote を設定
  - `git config branch.<actualBranch>.merge refs/heads/<actualBranch>` で merge 先を設定
- `electron/git/git-service.spec.ts` に upstream 設定を検証するテストを追加
  - sourceBranch 省略時のテスト
  - sourceBranch 指定時のテスト
- 実装プランドキュメント `docs/aidlc/workspace-core/construction/git_operations/plan-upstream.md` を追加

## テスト

- 新規テスト 2 件を追加し、upstream が正しく設定されることを検証
- 全テスト（Angular 33 件 + Electron 227 件）が成功
- lint, format チェックも成功

## 関連

- Closes #64
